### PR TITLE
Fix issue-9

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -7,5 +7,6 @@
 #
 # Please keep the list sorted.
 
+André Moraes <andre@amoraes.info / andrebq@gmail.com>
 Jim Teeuwen <jimteeuwen@gmail.com>
 Tim Howard <hai2you2@gmail.com>

--- a/fontdriver.go
+++ b/fontdriver.go
@@ -1,0 +1,77 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gltext
+
+import (
+	"errors"
+	"image"
+	"io"
+	"sync"
+)
+
+// Driver declares the signature required to enable easy replacement of
+// the text rendering engine.
+type Driver func(r io.Reader, scale int32, low, high rune, dir Direction) (*FontConfig, *image.RGBA, error)
+
+type driverManager struct {
+	sync.RWMutex
+	drivers       map[string]Driver
+	currentDriver Driver
+}
+
+var (
+	dm = driverManager{
+		drivers:       make(map[string]Driver),
+		currentDriver: nil,
+	}
+)
+
+// Register the given Driver under the given name.
+//
+// If a name is already used by other driver, this
+// will panic
+func RegisterDriver(name string, driver Driver) {
+	dm.Lock()
+	defer dm.Unlock()
+	if _, has := dm.drivers[name]; has {
+		panic(name + " already used")
+	}
+	dm.drivers[name] = driver
+}
+
+// Select the driver that should be used to render new glyphs,
+// old configurations aren't affected.
+func UseDriver(name string) error {
+	dm.Lock()
+	defer dm.Unlock()
+	if d, has := dm.drivers[name]; has {
+		dm.currentDriver = d
+		return nil
+	}
+	return errors.New(name + " isn't registred")
+}
+
+// MustUseDriver checks if the driver is valid and use it,
+// otherwise this panic
+func MustUseDriver(name string) {
+	err := UseDriver(name)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func LoadTruetype(r io.Reader, scale int32, low, high rune, dir Direction) (*Font, error) {
+	dm.Lock()
+	cur := dm.currentDriver
+	dm.Unlock()
+	if cur == nil {
+		return nil, errors.New("no driver is set")
+	}
+	fc, img, err := cur(r, scale, low, high, dir)
+	if err != nil {
+		return nil, err
+	}
+	return loadFont(img, fc)
+}

--- a/freetypedriver/doc.go
+++ b/freetypedriver/doc.go
@@ -1,0 +1,17 @@
+// This package uses freetype-go to implement the driver
+// interface for go-gl/gltext
+//
+// The freetype-go is dual licensed under FTL and GPLv2,
+//
+// The FTL license is similar to BSD but with an extra,
+// credit clause.
+//
+// You can read both licenses at:
+//
+// * https://code.google.com/p/freetype-go/source/browse/licenses/ftl.txt
+// * https://code.google.com/p/freetype-go/source/browse/licenses/gpl.txt
+package driver
+
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.

--- a/freetypedriver/freetype.go
+++ b/freetypedriver/freetype.go
@@ -1,46 +1,41 @@
 // Copyright 2012 The go-gl Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
-
-package gltext
+package driver
 
 import (
 	"code.google.com/p/freetype-go/freetype"
 	"code.google.com/p/freetype-go/freetype/truetype"
 	"github.com/go-gl/glh"
+	"github.com/go-gl/gltext"
 	"image"
 	"io"
 	"io/ioutil"
 )
 
-// http://www.freetype.org/freetype2/docs/tutorial/step2.html
+func init() {
+	gltext.RegisterDriver("freetype-go", LoadTruetype)
+	gltext.RegisterDriver("default", LoadTruetype)
+}
 
-// LoadTruetype loads a truetype font from the given stream and 
-// applies the given font scale in points.
-//
-// The low and high values determine the lower and upper rune limits
-// we should load for this font. For standard ASCII this would be: 32, 127.
-//
-// The dir value determines the orientation of the text we render
-// with this font. This should be any of the predefined Direction constants.
-func LoadTruetype(r io.Reader, scale int32, low, high rune, dir Direction) (*Font, error) {
+func LoadTruetype(r io.Reader, scale int32, low, high rune, dir gltext.Direction) (*gltext.FontConfig, *image.RGBA, error) {
 	data, err := ioutil.ReadAll(r)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Read the truetype font.
 	ttf, err := truetype.Parse(data)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	// Create our FontConfig type.
-	var fc FontConfig
+	var fc gltext.FontConfig
 	fc.Dir = dir
 	fc.Low = low
 	fc.High = high
-	fc.Glyphs = make(Charset, high-low+1)
+	fc.Glyphs = make(gltext.Charset, high-low+1)
 
 	// Create an image, large enough to store all requested glyphs.
 	//
@@ -100,5 +95,5 @@ func LoadTruetype(r io.Reader, scale int32, low, high rune, dir Direction) (*Fon
 		gi++
 	}
 
-	return loadFont(img, &fc)
+	return &fc, img, err
 }


### PR DESCRIPTION
New driver interface to enable easy replacement of font rendering
engines.

This also includes a default implementation using freetype-go
