### PR TITLE
Fix build

### DIFF
--- a/error.go
+++ b/error.go
@@ -1,0 +1,20 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gltext
+
+import (
+	"fmt"
+
+	"github.com/go-gl/gl/v2.1/gl"
+)
+
+// checkGLError returns an opengl error if one exists.
+func checkGLError() error {
+	errno := gl.GetError()
+	if errno == gl.NO_ERROR {
+		return nil
+	}
+	return fmt.Errorf("GL error: %d", errno)
+}

--- a/pow2.go
+++ b/pow2.go
@@ -1,0 +1,94 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gltext
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+)
+
+// Pow2 returns the first power-of-two value >= to n.
+// This can be used to create suitable texture dimensions.
+func Pow2(x uint32) uint32 {
+	x--
+	x |= x >> 1
+	x |= x >> 2
+	x |= x >> 4
+	x |= x >> 8
+	x |= x >> 16
+	return x + 1
+}
+
+// IsPow2 returns true if the given value is a power-of-two.
+func IsPow2(x uint32) bool { return (x & (x - 1)) == 0 }
+
+// Pow2Image returns the given image, scaled to the smallest power-of-two
+// dimensions larger or equal to the input dimensions.
+// It preserves the image format and contents.
+//
+// This is useful if an image is to be used as an OpenGL texture.
+// These often require image data to have power-of-two dimensions.
+func Pow2Image(src image.Image) image.Image {
+	sb := src.Bounds()
+	w, h := uint32(sb.Dx()), uint32(sb.Dy())
+
+	if IsPow2(w) && IsPow2(h) {
+		return src // Nothing to do.
+	}
+
+	rect := image.Rect(0, 0, int(Pow2(w)), int(Pow2(h)))
+
+	switch src := src.(type) {
+	case *image.Alpha:
+		return copyImg(src, image.NewAlpha(rect))
+
+	case *image.Alpha16:
+		return copyImg(src, image.NewAlpha16(rect))
+
+	case *image.Gray:
+		return copyImg(src, image.NewGray(rect))
+
+	case *image.Gray16:
+		return copyImg(src, image.NewGray16(rect))
+
+	case *image.NRGBA:
+		return copyImg(src, image.NewNRGBA(rect))
+
+	case *image.NRGBA64:
+		return copyImg(src, image.NewNRGBA64(rect))
+
+	case *image.Paletted:
+		return copyImg(src, image.NewPaletted(rect, src.Palette))
+
+	case *image.RGBA:
+		return copyImg(src, image.NewRGBA(rect))
+
+	case *image.RGBA64:
+		return copyImg(src, image.NewRGBA64(rect))
+	}
+
+	panic(fmt.Sprintf("Unsupported image format: %T", src))
+}
+
+// Why the image.Image interface does not support this,
+// I can never understand.
+type copyable interface {
+	image.Image
+	Set(x, y int, clr color.Color)
+}
+
+func copyImg(src, dst copyable) image.Image {
+	var x, y int
+	sb := src.Bounds()
+
+	for y = 0; y < sb.Dy(); y++ {
+		for x = 0; x < sb.Dx(); x++ {
+			dst.Set(x, y, src.At(x, y))
+		}
+	}
+
+	return dst
+}

--- a/pow2_test.go
+++ b/pow2_test.go
@@ -1,0 +1,43 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gltext
+
+import (
+	"testing"
+)
+
+func TestPow2(t *testing.T) {
+	tests := [...][2]uint32{
+		{0, 0}, {1, 1}, {2, 2}, {3, 4},
+		{4, 4}, {5, 8}, {6, 8}, {7, 8},
+		{8, 8}, {9, 16}, {10, 16},
+	}
+
+	for i := range tests {
+		ret := Pow2(tests[i][0])
+		if ret != tests[i][1] {
+			t.Fatalf("Pow2(%d): Want %d, Have %d",
+				tests[i][0], tests[i][1], ret)
+		}
+	}
+}
+
+func TestIsPow2(t *testing.T) {
+	tests := [...]struct {
+		In  uint32
+		Out bool
+	}{
+		{1, true}, {2, true}, {3, false}, {4, true}, {5, false},
+		{6, false}, {7, false}, {8, true}, {9, false}, {10, false},
+	}
+
+	for i := range tests {
+		ret := IsPow2(tests[i].In)
+		if ret != tests[i].Out {
+			t.Fatalf("isPow2(%d): Want %d, Have %d",
+				tests[i].In, tests[i].Out, ret)
+		}
+	}
+}

--- a/truetype.go
+++ b/truetype.go
@@ -5,17 +5,17 @@
 package gltext
 
 import (
-	"code.google.com/p/freetype-go/freetype"
-	"code.google.com/p/freetype-go/freetype/truetype"
-	"github.com/go-gl/glh"
 	"image"
 	"io"
 	"io/ioutil"
+
+	"code.google.com/p/freetype-go/freetype"
+	"code.google.com/p/freetype-go/freetype/truetype"
 )
 
 // http://www.freetype.org/freetype2/docs/tutorial/step2.html
 
-// LoadTruetype loads a truetype font from the given stream and 
+// LoadTruetype loads a truetype font from the given stream and
 // applies the given font scale in points.
 //
 // The low and high values determine the lower and upper rune limits
@@ -54,8 +54,8 @@ func LoadTruetype(r io.Reader, scale int32, low, high rune, dir Direction) (*Fon
 	gb := ttf.Bounds(scale)
 	gw := (gb.XMax - gb.XMin)
 	gh := (gb.YMax - gb.YMin) + 5
-	iw := glh.Pow2(uint32(gw * glyphsPerRow))
-	ih := glh.Pow2(uint32(gh * glyphsPerCol))
+	iw := Pow2(uint32(gw * glyphsPerRow))
+	ih := Pow2(uint32(gh * glyphsPerCol))
 
 	rect := image.Rect(0, 0, int(iw), int(ih))
 	img := image.NewRGBA(rect)


### PR DESCRIPTION
Hi. Take a look on what I've got so far. Now it can be built but there are some problems:

1. The function `checkGLError()` is a copy of the one in `go-gl/glh`, but as the original function used `glu` package, I removed this dependency, so it is useless on providing a GL error. It only returns `errno`. 
2. It depends only on `gl/v2.1/gl`. I don't know how to make it properly to make it possible to use it with other versions too. Maybe by using `glow`?
3. I have added `pow2*` files which are only copy/pasted from the original `go-gl/glh`. How should the credit to the original author be remained?
4. If you take a look at the output of the following code (which is horrible BTW), you can see, that there is some "dirt" when printing the text. I've found it is caused by the letter `i` (maybe it overflows to a different letter?)


I would appreciate some code review. Thank you.

```go
package main

import (
	_ "image/png"
	"log"
	"os"
	"runtime"

	"github.com/go-gl/gl/v2.1/gl"
	"github.com/go-gl/glfw/v3.1/glfw"
	"github.com/go-gl/gltext"
)

const (
	winWidth  = 1440
	winHeight = 900
)

var font *gltext.Font

func init() {
	runtime.LockOSThread()
}

func main() {
	if err := glfw.Init(); err != nil {
		log.Fatalln("failed to initialize glfw:", err)
	}
	defer glfw.Terminate()

	glfw.WindowHint(glfw.Resizable, glfw.False)
	glfw.WindowHint(glfw.ContextVersionMajor, 2)
	glfw.WindowHint(glfw.ContextVersionMinor, 1)
	window, err := glfw.CreateWindow(winWidth, winHeight, "Cube", nil, nil)
	if err != nil {
		panic(err)
	}
	window.SetKeyCallback(onKey)
	window.SetSizeCallback(onResize)
	window.MakeContextCurrent()

	if err := gl.Init(); err != nil {
		panic(err)
	}

	font, err = loadFont("luxisr.ttf", int32(44))
	if err != nil {
		log.Printf("LoadFont: %v", err)
		return
	}
	defer font.Release()

	setupScene()
	for !window.ShouldClose() {
		drawScene()
		window.SwapBuffers()
		glfw.PollEvents()
	}
}

// loadFont loads the specified font at the given scale.
func loadFont(file string, scale int32) (*gltext.Font, error) {
	fd, err := os.Open(file)
	if err != nil {
		return nil, err
	}
	defer fd.Close()
	return gltext.LoadTruetype(fd, scale, 32, 'ž'+1, gltext.LeftToRight)
}

// drawString draws the same string for each loaded font.
func drawString(x, y float32, str string) error {
	// We need to offset each string by the height of the
	// font. To ensure they don't overlap each other.
	_, h := font.GlyphBounds()
	y = y + float32(h)

	// Draw a rectangular backdrop using the string's metrics.
	sw, sh := font.Metrics(str)
	gl.Color4f(0.1, 0.1, 0.1, 0.7)
	gl.Rectf(x, y, x+float32(sw), y+float32(sh))

	// Render the string.
	gl.Color4f(1, 1, 1, 1)
	err := font.Printf(x, y, str)
	if err != nil {
		return err
	}
	return nil
}

func onKey(w *glfw.Window, key glfw.Key, scancode int, action glfw.Action, mods glfw.ModifierKey) {
	if action == glfw.Press {
		switch key {
		case glfw.KeyQ, glfw.KeyEscape:
			w.SetShouldClose(true)
		}
	}
}

func setupScene() {
	gl.Disable(gl.DEPTH_TEST)
	gl.Disable(gl.LIGHTING)
	gl.ClearColor(0.2, 0.2, 0.23, 0.0)
}

// onResize handles window resize events.
func onResize(W *glfw.Window, w, h int) {
	if w < 1 {
		w = 1
	}

	if h < 1 {
		h = 1
	}

	gl.Viewport(0, 0, int32(w), int32(h))
	gl.MatrixMode(gl.PROJECTION)
	gl.LoadIdentity()
	gl.Ortho(0, float64(w), float64(h), 0, 0, 1)
	gl.MatrixMode(gl.MODELVIEW)
	gl.LoadIdentity()
}

func printString(x, y float32, a string) {
	err := drawString(x, y, a)
	if err != nil {
		log.Printf("Printf: %v", err)
	}
}

func drawScene() {
	gl.Clear(gl.COLOR_BUFFER_BIT)
	step := getGen(70)
	printString(10, 10+step(), "ABCDEFG")
	printString(10, 10+step(), "ABCDEFG")
	printString(10, 10+step(), "0 1 2 3 4 5 6 7 8 9 A B C D E F")
	printString(10, 10+step(), "Příliš žluťoučký kůň úpěl ďábelské ódy.")
	printString(10, 10+step(), "Prilis zlutoucky kun upel dabelske ody.")
	printString(10, 10+step(), "Prli")
	printString(10, 10+step(), "ABCDEFG")
}

func getGen(step int) func() float32 {
	i := 0
	return func() float32 {
		i += step
		return float32(i - step)
	}
}
```