### PR TITLE
Updated to actually build and run.

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -10,3 +10,4 @@
 André Moraes <andre@amoraes.info / andrebq@gmail.com>
 Jim Teeuwen <jimteeuwen@gmail.com>
 Tim Howard <plash@komiga.com>
+Bryant Chandler <brychanrobot@gmail.com>

--- a/error.go
+++ b/error.go
@@ -1,0 +1,20 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gltext
+
+import (
+	"fmt"
+
+	"github.com/go-gl/gl/v2.1/gl"
+)
+
+// checkGLError returns an opengl error if one exists.
+func checkGLError() error {
+	errno := gl.GetError()
+	if errno == gl.NO_ERROR {
+		return nil
+	}
+	return fmt.Errorf("GL error: %d", errno)
+}

--- a/pow2.go
+++ b/pow2.go
@@ -1,0 +1,94 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gltext
+
+import (
+	"fmt"
+	"image"
+	"image/color"
+)
+
+// Pow2 returns the first power-of-two value >= to n.
+// This can be used to create suitable texture dimensions.
+func Pow2(x uint32) uint32 {
+	x--
+	x |= x >> 1
+	x |= x >> 2
+	x |= x >> 4
+	x |= x >> 8
+	x |= x >> 16
+	return x + 1
+}
+
+// IsPow2 returns true if the given value is a power-of-two.
+func IsPow2(x uint32) bool { return (x & (x - 1)) == 0 }
+
+// Pow2Image returns the given image, scaled to the smallest power-of-two
+// dimensions larger or equal to the input dimensions.
+// It preserves the image format and contents.
+//
+// This is useful if an image is to be used as an OpenGL texture.
+// These often require image data to have power-of-two dimensions.
+func Pow2Image(src image.Image) image.Image {
+	sb := src.Bounds()
+	w, h := uint32(sb.Dx()), uint32(sb.Dy())
+
+	if IsPow2(w) && IsPow2(h) {
+		return src // Nothing to do.
+	}
+
+	rect := image.Rect(0, 0, int(Pow2(w)), int(Pow2(h)))
+
+	switch src := src.(type) {
+	case *image.Alpha:
+		return copyImg(src, image.NewAlpha(rect))
+
+	case *image.Alpha16:
+		return copyImg(src, image.NewAlpha16(rect))
+
+	case *image.Gray:
+		return copyImg(src, image.NewGray(rect))
+
+	case *image.Gray16:
+		return copyImg(src, image.NewGray16(rect))
+
+	case *image.NRGBA:
+		return copyImg(src, image.NewNRGBA(rect))
+
+	case *image.NRGBA64:
+		return copyImg(src, image.NewNRGBA64(rect))
+
+	case *image.Paletted:
+		return copyImg(src, image.NewPaletted(rect, src.Palette))
+
+	case *image.RGBA:
+		return copyImg(src, image.NewRGBA(rect))
+
+	case *image.RGBA64:
+		return copyImg(src, image.NewRGBA64(rect))
+	}
+
+	panic(fmt.Sprintf("Unsupported image format: %T", src))
+}
+
+// Why the image.Image interface does not support this,
+// I can never understand.
+type copyable interface {
+	image.Image
+	Set(x, y int, clr color.Color)
+}
+
+func copyImg(src, dst copyable) image.Image {
+	var x, y int
+	sb := src.Bounds()
+
+	for y = 0; y < sb.Dy(); y++ {
+		for x = 0; x < sb.Dx(); x++ {
+			dst.Set(x, y, src.At(x, y))
+		}
+	}
+
+	return dst
+}

--- a/pow2_test.go
+++ b/pow2_test.go
@@ -1,0 +1,43 @@
+// Copyright 2012 The go-gl Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+package gltext
+
+import (
+	"testing"
+)
+
+func TestPow2(t *testing.T) {
+	tests := [...][2]uint32{
+		{0, 0}, {1, 1}, {2, 2}, {3, 4},
+		{4, 4}, {5, 8}, {6, 8}, {7, 8},
+		{8, 8}, {9, 16}, {10, 16},
+	}
+
+	for i := range tests {
+		ret := Pow2(tests[i][0])
+		if ret != tests[i][1] {
+			t.Fatalf("Pow2(%d): Want %d, Have %d",
+				tests[i][0], tests[i][1], ret)
+		}
+	}
+}
+
+func TestIsPow2(t *testing.T) {
+	tests := [...]struct {
+		In  uint32
+		Out bool
+	}{
+		{1, true}, {2, true}, {3, false}, {4, true}, {5, false},
+		{6, false}, {7, false}, {8, true}, {9, false}, {10, false},
+	}
+
+	for i := range tests {
+		ret := IsPow2(tests[i].In)
+		if ret != tests[i].Out {
+			t.Fatalf("isPow2(%d): Want %d, Have %d",
+				tests[i].In, tests[i].Out, ret)
+		}
+	}
+}

--- a/truetype.go
+++ b/truetype.go
@@ -5,17 +5,17 @@
 package gltext
 
 import (
-	"code.google.com/p/freetype-go/freetype"
-	"code.google.com/p/freetype-go/freetype/truetype"
-	"github.com/go-gl/glh"
 	"image"
 	"io"
 	"io/ioutil"
+
+	"code.google.com/p/freetype-go/freetype"
+	"code.google.com/p/freetype-go/freetype/truetype"
 )
 
 // http://www.freetype.org/freetype2/docs/tutorial/step2.html
 
-// LoadTruetype loads a truetype font from the given stream and 
+// LoadTruetype loads a truetype font from the given stream and
 // applies the given font scale in points.
 //
 // The low and high values determine the lower and upper rune limits
@@ -54,8 +54,8 @@ func LoadTruetype(r io.Reader, scale int32, low, high rune, dir Direction) (*Fon
 	gb := ttf.Bounds(scale)
 	gw := (gb.XMax - gb.XMin)
 	gh := (gb.YMax - gb.YMin) + 5
-	iw := glh.Pow2(uint32(gw * glyphsPerRow))
-	ih := glh.Pow2(uint32(gh * glyphsPerCol))
+	iw := Pow2(uint32(gw * glyphsPerRow))
+	ih := Pow2(uint32(gh * glyphsPerCol))
 
 	rect := image.Rect(0, 0, int(iw), int(ih))
 	img := image.NewRGBA(rect)


### PR DESCRIPTION
I think I've fixed all of the problems. It builds and runs correctly with my test program. The only thing I'm concerned about is line 87 in truetype.go where I subtracted half of a row from the y for every glyph. I had to do this because it was clipping half a row down for some reason. I can confirm that it works correctly with my change. You can see the results without my offset below.

![image](https://cloud.githubusercontent.com/assets/3506681/13505110/cb9b5370-e134-11e5-8419-8e86e6d4779e.png)
