### PR TITLE
README: Fix broken link to examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ licenses for more information about the requirements.
 
 Refer to [go-gl/examples/gltext][ex] for usage examples.
 
-[ex]: https://github.com/go-gl/examples/tree/master/gltext
+[ex]: https://github.com/go-gl/examples/tree/64b743f99c4e9151c09563e9be3339441eb9296b/gltext
 
 
 ### License


### PR DESCRIPTION
The gltext examples were removed in go-gl/examples#39 because they were unmaintained. Still, it's better to link to last available version than to have a 404 link.

Updates #21.

Given that no one seems to have bandwidth to support this package, it's between this option, or remove the section altogether.

I think a better followup would be to mark it more clearly that this repo has no maintainers and is out of date/in a bad shape, so users aren't surprised when coming to it after well-maintained repos like go-gl/glfw and go-gl/gl.

/cc @dominikh